### PR TITLE
Fix build on my machine

### DIFF
--- a/src/backends/generic/header/qgl.h
+++ b/src/backends/generic/header/qgl.h
@@ -239,6 +239,8 @@ typedef void ( APIENTRY * PFNGLUNIFORMMATRIX4FVARBPROC) (GLint location, GLsizei
 typedef void ( APIENTRY * PFNGLUSEPROGRAMOBJECTARBPROC) (GLhandleARB programObj);
 typedef void ( APIENTRY * PFNGLVALIDATEPROGRAMARBPROC) (GLhandleARB programObj);
 
+#endif /* GL_ARB_shader_objects */
+
 extern PFNGLATTACHOBJECTARBPROC qglAttachObjectARB;
 extern PFNGLCOMPILESHADERARBPROC qglCompileShaderARB;
 extern PFNGLCREATEPROGRAMOBJECTARBPROC qglCreateProgramObjectARB;
@@ -279,7 +281,7 @@ extern PFNGLUNIFORMMATRIX4FVARBPROC qglUniformMatrix4fvARB;
 extern PFNGLUSEPROGRAMOBJECTARBPROC qglUseProgramObjectARB;
 extern PFNGLVALIDATEPROGRAMARBPROC qglValidateProgramARB;
 
-#endif /* GL_ARB_shader_objects */
+
 
 /* -------------------------- GL_ARB_vertex_shader ------------------------- */
 
@@ -298,11 +300,13 @@ typedef void ( APIENTRY * PFNGLBINDATTRIBLOCATIONARBPROC) (GLhandleARB programOb
 typedef void ( APIENTRY * PFNGLGETACTIVEATTRIBARBPROC) (GLhandleARB programObj, GLuint index, GLsizei maxLength, GLsizei* length, GLint *size, GLenum *type, GLcharARB *name);
 typedef GLint ( APIENTRY * PFNGLGETATTRIBLOCATIONARBPROC) (GLhandleARB programObj, const GLcharARB* name);
 
+#endif /* GL_ARB_vertex_shader */
+
 extern PFNGLBINDATTRIBLOCATIONARBPROC qglBindAttribLocationARB;
 extern PFNGLGETACTIVEATTRIBARBPROC qglGetActiveAttribARB;
 extern PFNGLGETATTRIBLOCATIONARBPROC qglGetAttribLocationARB;
 
-#endif /* GL_ARB_vertex_shader */
+
 
 /* ------------------------- GL_ARB_fragment_shader ------------------------ */
 
@@ -356,9 +360,10 @@ extern PFNGLGETATTRIBLOCATIONARBPROC qglGetAttribLocationARB;
 
 typedef void ( APIENTRY * PFNGLTEXBUFFERARBPROC) (GLenum target, GLenum internalformat, GLuint buffer);
 
+#endif /* GL_ARB_texture_buffer_object */
+
 extern PFNGLTEXBUFFERARBPROC qglTexBufferARB;
 
-#endif /* GL_ARB_texture_buffer_object */
 
 /* ---------------------- GL_EXT_texture_buffer_object --------------------- */
 
@@ -373,9 +378,10 @@ extern PFNGLTEXBUFFERARBPROC qglTexBufferARB;
 
 typedef void ( APIENTRY * PFNGLTEXBUFFEREXTPROC) (GLenum target, GLenum internalformat, GLuint buffer);
 
+#endif /* GL_EXT_texture_buffer_object */
+
 extern PFNGLTEXBUFFEREXTPROC qglTexBufferEXT;
 
-#endif /* GL_EXT_texture_buffer_object */
 
 /* ----------------------------- GL_VERSION_3_0 ---------------------------- */
 
@@ -535,12 +541,12 @@ typedef void ( APIENTRY * PFNGLDRAWELEMENTSINSTANCEDPROC) (GLenum mode, GLsizei 
 typedef void ( APIENTRY * PFNGLPRIMITIVERESTARTINDEXPROC) (GLuint buffer);
 typedef void ( APIENTRY * PFNGLTEXBUFFERPROC) (GLenum target, GLenum internalFormat, GLuint buffer);
 
+#endif /* GL_VERSION_3_1 */
+
 extern PFNGLDRAWARRAYSINSTANCEDPROC qglDrawArraysInstanced;
 extern PFNGLDRAWELEMENTSINSTANCEDPROC qglDrawElementsInstanced;
 extern PFNGLPRIMITIVERESTARTINDEXPROC qglPrimitiveRestartIndex;
 extern PFNGLTEXBUFFERPROC qglTexBuffer;
-
-#endif /* GL_VERSION_3_1 */
 
 
 /* ---------------------- GL_ARB_vertex_buffer_object ---------------------- */
@@ -595,6 +601,8 @@ typedef GLboolean ( APIENTRY * PFNGLISBUFFERARBPROC) (GLuint buffer);
 typedef void * ( APIENTRY * PFNGLMAPBUFFERARBPROC) (GLenum target, GLenum access);
 typedef GLboolean ( APIENTRY * PFNGLUNMAPBUFFERARBPROC) (GLenum target);
 
+#endif /* GL_ARB_vertex_buffer_object */
+
 extern PFNGLBINDBUFFERARBPROC qglBindBufferARB;
 extern PFNGLBUFFERDATAARBPROC qglBufferDataARB;
 extern PFNGLBUFFERSUBDATAARBPROC qglBufferSubDataARB;
@@ -606,8 +614,6 @@ extern PFNGLGETBUFFERSUBDATAARBPROC qglGetBufferSubDataARB;
 extern PFNGLISBUFFERARBPROC qglIsBufferARB;
 extern PFNGLMAPBUFFERARBPROC qglMapBufferARB;
 extern PFNGLUNMAPBUFFERARBPROC qglUnmapBufferARB;
-
-#endif /* GL_ARB_vertex_buffer_object */
 
 /* ----------------------------- GL_VERSION_1_5 ---------------------------- */
 
@@ -688,6 +694,8 @@ typedef GLboolean ( APIENTRY * PFNGLISQUERYPROC) (GLuint id);
 typedef void* ( APIENTRY * PFNGLMAPBUFFERPROC) (GLenum target, GLenum access);
 typedef GLboolean ( APIENTRY * PFNGLUNMAPBUFFERPROC) (GLenum target);
 
+#endif /* GL_VERSION_1_5 */
+
 extern PFNGLBEGINQUERYPROC qglBeginQuery;
 extern PFNGLBINDBUFFERPROC qglBindBuffer;
 extern PFNGLBUFFERDATAPROC qglBufferData;
@@ -708,7 +716,6 @@ extern PFNGLISQUERYPROC qglIsQuery;
 extern PFNGLMAPBUFFERPROC qglMapBuffer;
 extern PFNGLUNMAPBUFFERPROC qglUnmapBuffer;
 
-#endif /* GL_VERSION_1_5 */
 
 /* --------------------------- GL_ARB_texture_rg --------------------------- */
 
@@ -757,10 +764,11 @@ extern PFNGLUNMAPBUFFERPROC qglUnmapBuffer;
 typedef void ( APIENTRY * PFNGLFLUSHMAPPEDBUFFERRANGEPROC) (GLenum target, GLintptr offset, GLsizeiptr length);
 typedef void * ( APIENTRY * PFNGLMAPBUFFERRANGEPROC) (GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
 
+#endif /* GL_ARB_map_buffer_range */
+
 extern PFNGLFLUSHMAPPEDBUFFERRANGEPROC qglFlushMappedBufferRange;
 extern PFNGLMAPBUFFERRANGEPROC qglMapBufferRange;
 
-#endif /* GL_ARB_map_buffer_range */
 
 /* ----------------------------- GL_VERSION_1_2 ---------------------------- */
 
@@ -813,11 +821,11 @@ typedef void ( APIENTRY * PFNGLDRAWRANGEELEMENTSPROC) (GLenum mode, GLuint start
 typedef void ( APIENTRY * PFNGLTEXIMAGE3DPROC) (GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void *pixels);
 typedef void ( APIENTRY * PFNGLTEXSUBIMAGE3DPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void *pixels);
 
+#endif /* GL_VERSION_1_2 */
+
 extern PFNGLCOPYTEXSUBIMAGE3DPROC qglCopyTexSubImage3D;
 extern PFNGLDRAWRANGEELEMENTSPROC qglDrawRangeElements;
 extern PFNGLTEXIMAGE3DPROC qglTexImage3D;
 extern PFNGLTEXSUBIMAGE3DPROC qglTexSubImage3D;
-
-#endif /* GL_VERSION_1_2 */
 
 #endif

--- a/src/client/refresh/r_pathtracing.c
+++ b/src/client/refresh/r_pathtracing.c
@@ -426,7 +426,9 @@ AddPointLight(entitylight_t *entity)
 	
 	poly_offset = pt_num_vertices;
 	
-	static const vec3_t d = { 1.0, sqrt(2.0 / 3.0) * 0.5, sqrt(3.0) / 2.0 };
+	//static const vec3_t d = { 1.0, sqrt(2.0 / 3.0) * 0.5, sqrt(3.0) / 2.0 };
+
+	static const vec3_t d = { 1.0, 0.40824829, 0.8660254 };
 	
 	const vec3_t tetrahedron_vertices[PT_NUM_ENTITY_VERTICES] = {
 			{-d[0], -d[1], -d[2]},
@@ -598,7 +600,7 @@ AddStaticLights(void)
 						PT_ASSERT(ind[k + 3] >= 0 && ind[k + 3] < pt_num_vertices);
 
 						x = pt_vertex_data[ind[k + 2] * pt_vertex_stride + j] + pt_vertex_data[ind[k] * pt_vertex_stride + j] - pt_vertex_data[ind[k + 1] * pt_vertex_stride + j];
-						if (abs(x - pt_vertex_data[ind[k + 3] * pt_vertex_stride + j]) > 0.25)
+						if (fabsf(x - pt_vertex_data[ind[k + 3] * pt_vertex_stride + j]) > 0.25)
 							break;
 					}
 					if (j == 3)


### PR DESCRIPTION
- apparently my system gl.h #defines GL_ARB_shader_objects etc, so when
  building I don't run into the #ifndef GL_ARB_shader_objects case
  (same for all the similar cases in qgl.h).
  For that reason, the
  "extern PFNGLATTACHOBJECTARBPROC qglAttachObjectARB;" declarations
  were also hidden by the #ifndef and couldn't be found elsewhere.
  I moved the #endif above those qgl\* declarations to fix that.
- clang complained that sqrt(2.0 / 3.0) \* 0.5 is no compiletime constant
  and for that reason didn't want to use it in
  static const vec3_t d = { 1.0, sqrt(2.0 / 3.0) \* 0.5,... };
  I just replaced it with the result of the calculation
- clang warned that abs() is for integers, and for floats fabsf() should
  be used. makes sense when comparing to 0.25..
  (Note that older MSVC versions had abs() overloaded for float etc,
  at least in C++ mode, so there it effectively did fabsf(). Afaik
  it does not do that anymore and gcc and clang certainly don't.)
